### PR TITLE
Remove iOS reference in podspec

### DIFF
--- a/RxSwift.podspec
+++ b/RxSwift.podspec
@@ -29,6 +29,7 @@ Pod::Spec.new do |s|
   s.author           = { "Krunoslav Zaher" => "krunoslav.zaher@gmail.com" }
   s.source           = { :git => "https://github.com/kzaher/RxSwift.git", :tag => s.version.to_s }
   s.requires_arc = true
-
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.9'
   s.source_files = 'RxSwift/RxSwift/**/*.swift'
 end

--- a/RxSwift.podspec
+++ b/RxSwift.podspec
@@ -28,8 +28,7 @@ Pod::Spec.new do |s|
   s.license          = 'MIT'
   s.author           = { "Krunoslav Zaher" => "krunoslav.zaher@gmail.com" }
   s.source           = { :git => "https://github.com/kzaher/RxSwift.git", :tag => s.version.to_s }
-
   s.requires_arc = true
 
-  s.source_files = 'RxSwift/RxSwift/**/*'
+  s.source_files = 'RxSwift/RxSwift/**/*.swift'
 end

--- a/RxSwift.podspec
+++ b/RxSwift.podspec
@@ -29,7 +29,6 @@ Pod::Spec.new do |s|
   s.author           = { "Krunoslav Zaher" => "krunoslav.zaher@gmail.com" }
   s.source           = { :git => "https://github.com/kzaher/RxSwift.git", :tag => s.version.to_s }
 
-  s.platform     = :ios, '8.0'
   s.requires_arc = true
 
   s.source_files = 'RxSwift/RxSwift/**/*'


### PR DESCRIPTION
Hello there, wanted to use this in a Mac app. Opted to remove the iOS only reference. The other option is to state a version for OS X and iOS. I have no major preference.