### PR TITLE
Swift 2.0 iOS 9.4 Fix for observeValueForKeyPath Change

### DIFF
--- a/RxCocoa/RxCocoa/Common/Observables/Implementations/KVOObservable.swift
+++ b/RxCocoa/RxCocoa/Common/Observables/Implementations/KVOObservable.swift
@@ -41,7 +41,7 @@ class KVOObserver : NSObject
         self.parent.object.addObserver(self, forKeyPath: self.parent.path, options: self.parent.options, context: &context)
     }
     
-    override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [NSObject : AnyObject]?, context: UnsafeMutablePointer<Void>) {
+    override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
         let newValue: AnyObject? = change?[NSKeyValueChangeNewKey]
         
         if let newValue: AnyObject = newValue {


### PR DESCRIPTION
With this fix RxSwift and RxCocoa work with Swift 2.0 in the Xcode 7.0 beta 3. 
Due to Apples changes to NSKeyValueObserving found [here](https://developer.apple.com/library/prerelease/ios/releasenotes/General/iOS90APIDiffs/frameworks/Foundation.html)
All unit tests are currently passing on iOS and OS X